### PR TITLE
Fix cstring double decay

### DIFF
--- a/so/c/c.go
+++ b/so/c/c.go
@@ -66,7 +66,7 @@ func Bytes(ptr *byte, n int) []byte {
 // CString converts a So string to a null-terminated C string.
 // Allocates memory on the stack using alloca until the calling function returns.
 //
-//so:extern so_cstr
+//so:extern so_cstr nodecay
 func CString(s string) *Char {
 	return (*Char)(unsafe.StringData(s))
 }

--- a/testdata/std/c/dst/main.c
+++ b/testdata/std/c/dst/main.c
@@ -38,5 +38,11 @@ int main(void) {
             so_panic("b != 7");
         }
     }
+    {
+        // Go string to C string conversion.
+        so_String s = so_str("hello");
+        so_const_char* p = (so_const_char*)(so_cstr(s));
+        (void)p;
+    }
     return 0;
 }

--- a/testdata/std/c/src/main.go
+++ b/testdata/std/c/src/main.go
@@ -49,4 +49,10 @@ func main() {
 			panic("b != 7")
 		}
 	}
+	{
+		// Go string to C string conversion.
+		s := "hello"
+		p := (*c.ConstChar)(c.CString(s))
+		_ = p
+	}
 }


### PR DESCRIPTION
Found with:

```go
vertSrc := (*c.ConstChar)(c.CString(shapeVertexShader))
```

```
/var/folders/lb/nhsppbxs5_v27pn_x3kf66wc0000gn/T/solod_build984939367/soglad.c:686:47: error: initializing 'so_String' with an expression of incompatible type 'char *'
  686 |     so_const_char* vertSrc = (so_const_char*)(so_cstr(so_cstr(shapeVertexShader)));
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/folders/lb/nhsppbxs5_v27pn_x3kf66wc0000gn/T/solod_build984939367/so/builtin/builtin.h:91:15: note: expanded from macro 'so_cstr'
   91 |     so_String _s = (s);                                   \
      |               ^    ~~~
```