### PR TITLE
builtin.h: skip alloca.h include on OpenBSD

### DIFF
--- a/internal/compiler/builtin/builtin.h
+++ b/internal/compiler/builtin/builtin.h
@@ -4,7 +4,7 @@
 
 #ifdef _WIN32
 #include <malloc.h>
-#else
+#elif !defined(__OpenBSD__)
 #include <alloca.h>
 #endif
 


### PR DESCRIPTION
alloca() is provided by stdlib.h on OpenBSD, so the separate alloca.h include is not needed and causes a faild build.