### PR TITLE
FunFor: returns nil if T is unsupported

### DIFF
--- a/so/cmp/cmp.go
+++ b/so/cmp/cmp.go
@@ -56,9 +56,7 @@ func FuncFor[T any]() Func {
 			return cmp.Compare(s1, s2)
 		}
 	}
-	return func(a, b any) int {
-		return mem.Compare(a, b, c.Sizeof[T]())
-	}
+	return nil
 }
 
 // Compare returns


### PR DESCRIPTION
Was confused reading the Go code until I saw it does return NULL in the C one. I think the 2 should be aligned.